### PR TITLE
ci: add pnpm audit workflow triggered by PR label

### DIFF
--- a/.github/workflows/pnpm-audit.yml
+++ b/.github/workflows/pnpm-audit.yml
@@ -45,10 +45,14 @@ jobs:
             STATUS="⚠️ Vulnerabilities detected."
           fi
 
-          gh pr comment "$PR_NUMBER" --body "## pnpm audit
+          {
+            echo "## pnpm audit"
+            echo ""
+            echo "$STATUS"
+            echo ""
+            echo '```'
+            echo "$AUDIT_RESULT"
+            echo '```'
+          } > /tmp/audit-body.md
 
-${STATUS}
-
-\`\`\`
-${AUDIT_RESULT}
-\`\`\`"
+          gh pr comment "$PR_NUMBER" --body-file /tmp/audit-body.md

--- a/.github/workflows/pnpm-audit.yml
+++ b/.github/workflows/pnpm-audit.yml
@@ -1,0 +1,54 @@
+name: pnpm audit
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  audit:
+    if: github.event.label.name == 'audit'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run pnpm audit and post result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set +e
+          AUDIT_RESULT=$(pnpm audit 2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            STATUS="✅ No vulnerabilities found."
+          else
+            STATUS="⚠️ Vulnerabilities detected."
+          fi
+
+          gh pr comment "$PR_NUMBER" --body "## pnpm audit
+
+${STATUS}
+
+\`\`\`
+${AUDIT_RESULT}
+\`\`\`"


### PR DESCRIPTION
## Summary

- `audit` ラベルが付いたPRでのみ起動するGitHub Actionsワークフローを追加
- `pnpm audit` を実行し、結果を `gh pr comment` でPRコメントに書き込む
- 脆弱性なし → ✅、あり → ⚠️ でステータスを表示

## Test plan

- [ ] `audit` ラベルをPRに付けてワークフローが起動することを確認
- [ ] PRコメントに audit 結果が書き込まれることを確認
- [ ] `audit` 以外のラベルではワークフローがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)